### PR TITLE
Missing Storybook Dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "awesome-typescript-loader": "^5.2.1",
     "babel-loader": "^8.0.6",
     "babel-plugin-styled-components": "^1.10.6",
+    "babel-preset-react-app": "^9.1.2",
     "jest": "^24.9.0",
     "postcss-easy-import": "^3.0.0",
     "postcss-preset-env": "^6.7.0",


### PR DESCRIPTION
Add the `babel-preset-react-app` npm dependency your bundle requires to properly run Storybook.